### PR TITLE
Use Python from target environment

### DIFF
--- a/conda_pupa/build.py
+++ b/conda_pupa/build.py
@@ -20,7 +20,7 @@ from conda_package_streaming.create import conda_builder
 
 from build import ProjectBuilder, check_dependency
 
-from . import installer
+from . import installer, paths
 from .conda_build_utils import PathType, sha256_checksum
 from .translate import CondaMetadata, requires_to_conda
 
@@ -97,12 +97,17 @@ def ensure_requirements(requirements):
 
 
 def build_pypa(
-    path: Path, output_path, python_executable: str, distribution="editable"
+    path: Path,
+    output_path,
+    prefix: Path,
+    distribution="editable",
 ):
     """
     Args:
         distribution: "editable" or "wheel"
     """
+    python_executable = str(paths.get_python_executable(prefix))
+
     builder = ProjectBuilder(path, python_executable=python_executable)
 
     build_system_requires = builder.build_system_requires
@@ -200,7 +205,12 @@ def update_RECORD(record_path: Path, base_path: Path, changed_path: Path):
         writer.writerows(record_rows)
 
 
-def pypa_to_conda(project, distribution="editable", output_path: Path | None = None):
+def pypa_to_conda(
+    project,
+    prefix: Path,
+    distribution="editable",
+    output_path: Path | None = None,
+):
     project = Path(project)
 
     # Should this logic be moved to the caller?
@@ -213,7 +223,7 @@ def pypa_to_conda(project, distribution="editable", output_path: Path | None = N
         tmp_path = Path(tmp_path)
 
         normal_wheel = build_pypa(
-            Path(project), tmp_path, sys.executable, distribution=distribution
+            Path(project), tmp_path, prefix=prefix, distribution=distribution
         )
 
         build_path = tmp_path / "build"

--- a/conda_pupa/build.py
+++ b/conda_pupa/build.py
@@ -213,7 +213,7 @@ def pypa_to_conda(
 
     try:
         tmp_manager = tempfile.TemporaryDirectory(prefix="conda", delete=False)
-    except TypeError:
+    except TypeError:  # pragma: no cover
         # < Python 3.12 but output_path ought to exist
         tmp_manager = tempfile.TemporaryDirectory(prefix="conda")
 

--- a/conda_pupa/build.py
+++ b/conda_pupa/build.py
@@ -219,7 +219,13 @@ def pypa_to_conda(
         if not output_path.exists():
             output_path.mkdir()
 
-    with tempfile.TemporaryDirectory(prefix="conda", delete=False) as tmp_path:
+    try:
+        tmp_manager = tempfile.TemporaryDirectory(prefix="conda", delete=False)
+    except TypeError:
+        # < Python 3.12 but output_path ought to exist
+        tmp_manager = tempfile.TemporaryDirectory(prefix="conda")
+
+    with tmp_manager as tmp_path:
         tmp_path = Path(tmp_path)
 
         normal_wheel = build_pypa(

--- a/conda_pupa/cli.py
+++ b/conda_pupa/cli.py
@@ -5,6 +5,7 @@ Command line interface for conda-pupa.
 from pathlib import Path
 
 import click
+import conda.base.context
 
 import conda_pupa.build
 import conda_pupa.convert_tree
@@ -67,11 +68,19 @@ def cli(
     if output_folder:
         output_folder = Path(output_folder)
 
+    if prefix:
+        prefix = Path(prefix).expanduser()
+    else:
+        prefix = Path(conda.base.context.context.target_prefix)
+
     if editable:
         print(
             "Editable at ",
             conda_pupa.build.pypa_to_conda(
-                editable, distribution="editable", output_path=output_folder
+                editable,
+                distribution="editable",
+                output_path=output_folder,
+                prefix=prefix,
             ),
         )
 
@@ -79,15 +88,11 @@ def cli(
         print(
             "Conda package at ",
             conda_pupa.build.pypa_to_conda(
-                build, distribution="wheel", output_path=output_folder
+                build, distribution="wheel", output_path=output_folder, prefix=prefix
             ),
         )
 
     else:
-        if prefix:
-            prefix = Path(prefix).expanduser()
-        # XXX or environment name plus default prefix
-
         converter = conda_pupa.convert_tree.ConvertTree(
             prefix, override_channels=override_channels
         )

--- a/conda_pupa/convert_tree.py
+++ b/conda_pupa/convert_tree.py
@@ -9,8 +9,8 @@ from pathlib import Path
 
 import conda.exceptions
 import platformdirs
-from conda.common.path import get_python_short_path
 from conda.base.context import context
+from conda.common.path import get_python_short_path
 from conda.models.channel import Channel
 from conda.models.match_spec import MatchSpec
 from conda_libmamba_solver.solver import LibMambaSolver, LibMambaUnsatisfiableError

--- a/conda_pupa/dependencies.py
+++ b/conda_pupa/dependencies.py
@@ -1,0 +1,43 @@
+"""
+Check dependencies in a prefix, either by using Conda's functionality or
+Python's in a subprocess.
+"""
+
+import importlib.resources
+import json
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+from conda.cli.main import main_subshell
+
+from . import paths
+from .translate import requires_to_conda
+
+
+def check_dependencies(requirements: Iterable[str], prefix: Path):
+    python_executable = str(paths.get_python_executable(prefix))
+    dependency_getter = importlib.resources.read_text(
+        "conda_pupa", "dependencies_subprocess.py"
+    )
+    result = subprocess.run(
+        [
+            python_executable,
+            "-",
+            "-r",
+            json.dumps(sorted(requirements)),
+        ],
+        encoding="utf-8",
+        input=dependency_getter,
+        capture_output=True,
+    )
+    missing = json.loads(result.stdout)
+
+    return missing
+
+
+def ensure_requirements(requirements: list[str], prefix: Path):
+    if requirements:
+        conda_requirements, _ = requires_to_conda(requirements)
+        # -y may be appropriate during tests only
+        main_subshell("install", "--prefix", str(prefix), "-y", *conda_requirements)

--- a/conda_pupa/dependencies_subprocess.py
+++ b/conda_pupa/dependencies_subprocess.py
@@ -1,0 +1,24 @@
+"""
+Run under target Python interpreter to get dependencies using pypa/build.
+
+Alternative implementation would use conda PrefixData plus conda/pypi name
+translation; but this one supports extras and the format in pyproject.toml.
+"""
+
+import json
+import sys
+
+import build
+
+
+def check_dependencies(build_system_requires):
+    missing = [u for d in build_system_requires for u in build.check_dependency(d)]
+    return missing
+
+
+if __name__ == "__main__":
+    name, flag, requirements = sys.argv
+    assert flag == "-r"
+    requirements = json.loads(requirements)
+    stuff = check_dependencies(requirements)
+    print(json.dumps(stuff))

--- a/conda_pupa/dependencies_subprocess.py
+++ b/conda_pupa/dependencies_subprocess.py
@@ -16,9 +16,13 @@ def check_dependencies(build_system_requires):
     return missing
 
 
-if __name__ == "__main__":
-    name, flag, requirements = sys.argv
+def main(argv):
+    name, flag, requirements = argv
     assert flag == "-r"
     requirements = json.loads(requirements)
     stuff = check_dependencies(requirements)
-    print(json.dumps(stuff))
+    return json.dumps(stuff)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print(main(sys.argv))

--- a/conda_pupa/paths.py
+++ b/conda_pupa/paths.py
@@ -1,0 +1,11 @@
+"""
+Paths we need to know.
+"""
+
+from pathlib import Path
+
+import conda.common.path
+
+
+def get_python_executable(prefix: Path):
+    return Path(prefix, conda.common.path.get_python_short_path())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "conda-package-streaming >=0.11",
   "installer >=0.7",                 # conda name is python-installer
   "packaging >=24",
-  "unearth>=0.17.2",                 # download packages from pypi
+  "unearth >=0.17.2",                 # download packages from pypi
 ]
 
 [project.optional-dependencies]

--- a/tests/packages/has-build-dep/pyproject.toml
+++ b/tests/packages/has-build-dep/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+# sphinxcontrib has no deps and is unlikely to exist in parent environment
+requires = ["flit_core", "sphinxcontrib"]
+
+[project]
+name = "has_dep"
+version = "1"
+description = "has dependency unlikely to exist in test environment"

--- a/tests/test_conda_create.py
+++ b/tests/test_conda_create.py
@@ -4,10 +4,10 @@ import os
 from pathlib import Path
 
 from conda.cli.main import main_subshell
+from conda_package_streaming.create import conda_builder
 
 from conda_pupa.build import filter, paths_json
 from conda_pupa.conda_build_utils import PathType, sha256_checksum
-from conda_package_streaming.create import conda_builder
 from conda_pupa.index import update_index
 from conda_pupa.translate import PackageRecord
 

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -13,11 +13,13 @@ from conda_pupa.dependencies import ensure_requirements
 
 
 def test_editable(tmp_path):
+    # Other tests can change context.target_prefix by calling "conda install
+    # --prefix", so we use default_prefix; could alternatively reset context.
     pypa_to_conda(
         Path(__file__).parents[1],
         output_path=tmp_path,
         distribution="editable",
-        prefix=Path(context.target_prefix),
+        prefix=Path(context.default_prefix),
     )
 
 
@@ -62,7 +64,7 @@ def test_build_wheel(package, package_path, tmp_path):
             package_path / package,
             output_path=tmp_path,
             distribution="wheel",
-            prefix=Path(context.target_prefix),
+            prefix=Path(context.default_prefix),
         )
     except (
         build.BuildException,
@@ -91,7 +93,7 @@ def test_filter_coverage():
 def test_create_build_dir(tmp_path):
     # XXX should "create default output_path" logic live in pypa_to_conda?
     with pytest.raises(build.BuildException):
-        pypa_to_conda(tmp_path, prefix=Path(context.target_prefix))
+        pypa_to_conda(tmp_path, prefix=Path(context.default_prefix))
 
 
 ## Test pupa installed in different environment than editable package / activated environment...

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -8,7 +8,8 @@ from conda.core.prefix_data import PrefixData
 from packaging.requirements import InvalidRequirement
 
 import build
-from conda_pupa.build import ensure_requirements, filter, pypa_to_conda
+from conda_pupa.build import filter, pypa_to_conda
+from conda_pupa.dependencies import ensure_requirements
 
 
 def test_editable(tmp_path):
@@ -74,10 +75,10 @@ def test_build_wheel(package, package_path, tmp_path):
 
 
 def test_ensure_requirements(mocker):
-    mock = mocker.patch("conda_pupa.build.main_subshell")
-    ensure_requirements(["flit_core"])
+    mock = mocker.patch("conda_pupa.dependencies.main_subshell")
+    ensure_requirements(["flit_core"], prefix=Path())
     # normalizes/converts the underscore flit_core->flit-core
-    assert mock.call_args.args == ("install", "-y", "flit-core")
+    assert mock.call_args.args == ("install", "--prefix", ".", "-y", "flit-core")
 
 
 def test_filter_coverage():
@@ -103,6 +104,7 @@ def test_build_in_env(tmp_path):
         str(tmp_path / "env"),
         "-y",
         "python",
+        "python-build",
     )
 
     prefix = str(tmp_path / "env")

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -2,6 +2,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from conda.base.context import context
 from conda.cli.main import main_subshell
 from conda.core.prefix_data import PrefixData
 from packaging.requirements import InvalidRequirement
@@ -12,7 +13,10 @@ from conda_pupa.build import ensure_requirements, filter, pypa_to_conda
 
 def test_editable(tmp_path):
     pypa_to_conda(
-        Path(__file__).parents[1], output_path=tmp_path, distribution="editable"
+        Path(__file__).parents[1],
+        output_path=tmp_path,
+        distribution="editable",
+        prefix=Path(context.target_prefix),
     )
 
 
@@ -54,7 +58,10 @@ def test_build_wheel(package, package_path, tmp_path):
         )
     try:
         pypa_to_conda(
-            package_path / package, output_path=tmp_path, distribution="wheel"
+            package_path / package,
+            output_path=tmp_path,
+            distribution="wheel",
+            prefix=Path(context.target_prefix),
         )
     except (
         build.BuildException,
@@ -83,7 +90,7 @@ def test_filter_coverage():
 def test_create_build_dir(tmp_path):
     # XXX should "create default output_path" logic live in pypa_to_conda?
     with pytest.raises(build.BuildException):
-        pypa_to_conda(tmp_path)
+        pypa_to_conda(tmp_path, prefix=Path(context.target_prefix))
 
 
 ## Test pupa installed in different environment than editable package / activated environment...

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 from pathlib import Path
 
@@ -8,6 +9,7 @@ from conda.core.prefix_data import PrefixData
 from packaging.requirements import InvalidRequirement
 
 import build
+import conda_pupa.dependencies_subprocess
 from conda_pupa.build import filter, pypa_to_conda
 from conda_pupa.dependencies import ensure_requirements
 
@@ -129,3 +131,16 @@ def test_build_in_env(tmp_path):
     ]
 
     assert "sphinxcontrib" in installed
+
+
+def test_dependencies_subprocess():
+    """
+    Normally called in a way that doesn't measure coverage.
+    """
+    dependencies = ["xyzzy", "conda"]
+    missing_dependencies = conda_pupa.dependencies_subprocess.main(
+        ["-", "-r", json.dumps(dependencies)]
+    )
+    # A list per checked dependency, if that dependency or its dependencies are
+    # missing.
+    assert json.loads(missing_dependencies) == [["xyzzy"]]

--- a/tests/test_repodata.py
+++ b/tests/test_repodata.py
@@ -2,7 +2,7 @@
 Test functions for transforming repodata.
 """
 
-from conda_pupa.translate import FileDistribution, conda_to_requires, MatchSpec
+from conda_pupa.translate import FileDistribution, MatchSpec, conda_to_requires
 
 
 def test_file_distribution():


### PR DESCRIPTION
Fix #1 

Use Python executable, dependencies list from target environment instead of conda's environment.